### PR TITLE
Fixed Typo From 'generating-retroarch-logs.md'

### DIFF
--- a/docs/guides/generating-retroarch-logs.md
+++ b/docs/guides/generating-retroarch-logs.md
@@ -18,7 +18,7 @@ Next We'll activate the logging option:
 2. Enter at "Logging"
 3. Activate "Log to File"
 4.(optional) Customize Core & Frontend Logging Level & if you want timestamps or performance counters on your log
-5. Acttivate "Logging Verbosity"
+5. Activate "Logging Verbosity"
 
 ### Generating Logs in Lakka
 [Please see the Troubleshooting Lakka doc](http://www.lakka.tv/doc/Troubleshooting-Lakka/).


### PR DESCRIPTION
Changed from '5. Acttivate "Logging Verbosity"' to '5. Activate "Logging Verbosity"'.